### PR TITLE
Remove roiStaffName references after Codex deleted the HTML element

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -76,7 +76,6 @@ const fields = {
   staffRole: $("staffRole"),
   roiClientName: $("roiClientName"),
   roiClientDob: $("roiClientDob"),
-  roiStaffName: $("roiStaffName"),
   roiPurpose: $("roiPurpose"),
   roiOrganization: $("roiOrganization"),
   roiCareOf: $("roiCareOf"),
@@ -138,7 +137,6 @@ function renderView() {
 function bindLiveText() {
   fields.roiClientName.textContent = clientFullName(state);
   fields.roiClientDob.textContent = state.general.dob || "";
-  fields.roiStaffName.textContent = staffFullName(state);
   fields.noticeClientName.textContent = clientFullName(state);
   fields.noticeClientDob.textContent = state.general.dob || "";
   fields.noticeStaffName.textContent = staffFullName(state);


### PR DESCRIPTION
Codex removed the <span id="roiStaffName"> from index.html but left the JS lookup and binding, causing a null reference crash on every renderState/wipePhi call.

https://claude.ai/code/session_01HBUSniLU76cFYxWwfq6ZF2